### PR TITLE
Remove the shell fight from Arena01

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,13 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches:
+      - main
+      - preview
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
+      - preview
 
 jobs:
   build:

--- a/arenas/arena01/src/challenges/print-string/challenge-en.md
+++ b/arenas/arena01/src/challenges/print-string/challenge-en.md
@@ -1,5 +1,35 @@
-Write a function called printString that takes a string as a parameter and displays it on the standard output in the same way as console.log().
+In all courses, they start with a `console.log("Hello world!")`. 
+
+In the Arena, we expect you to develop a deeper understanding than that.
+
+So, your first challenge is to recode a `console.log()`. 
+
+You can only use the method process.stdout.write(). 
+
+To be clear: `console.log()` is forbidden. 
+
+Write a function called printString that takes a string as a parameter and displays it on the standard output in the same way as `console.log()`.
+
+Here is the type of the function you have to write:
 
 ```typescript
 type PrintStringFn = (str: string) => void
 ```
+
+To submit your work, clone the repository, add a directory named `print-string`, add your code in a file named `index.ts`, and export your function as follows:
+
+```typescript
+type PrintStringFn = (str: string) => void;
+
+export const printString: PrintStringFn = (str) => {
+   // your code here
+};
+```
+
+Then, commit your work and push it to your repository.
+
+Note: For every challenge, look carefully at the instructions, especially the submission directory and file names, the function name, and the allowed methods. 
+
+If no function or method is allowed, it means it's forbidden by default.
+
+Good luck!

--- a/arenas/arena01/src/challenges/print-string/challenge.md
+++ b/arenas/arena01/src/challenges/print-string/challenge.md
@@ -1,5 +1,31 @@
-Écrire une fonction appelée printString qui prend une chaîne de caractères en paramètre et l'affiche sur la sortie standard de la même manière qu'un `console.log()`.
+La majorité des cours commencent avec un console.log("Hello world!").
+
+Dans l'Arène, on s'attend à ce que tu développes une compréhension plus approfondie que cela.
+
+Ton premier défi est donc de recoder un `console.log()`.
+
+Tu peux seulement utiliser la méthode `process.stdout.write()`.
+
+Pour être clair : `console.log()` est interdit. 
+
+Écris une fonction appelée `printString` qui prend une chaîne de caractères en paramètre et l'affiche sur la sortie standard de la même manière que console.log().
+
+Voici le type de fonction que tu dois écrire :
 
 ```typescript
 type PrintStringFn = (str: string) => void
 ```
+
+Pour soumettre ton travail, clone le repository, ajoute un dossier nommé `print-string`, ajoute ton code dans un fichier nommé `index.ts`, et exporte ta fonction comme suit :
+
+```typescript
+export const printString: PrintStringFn = (str: string) => {
+   // ton code ici
+};
+```
+
+Note : Pour chaque défi, lis attentivement les instructions, en particulier les noms de dossier et de fichier de rendu, le nom de la fonction et les méthodes autorisées. 
+
+Si aucune fonction ou méthode n'est autorisée, cela signifie qu'elle est interdite par défaut.
+
+Bonne chance !

--- a/arenas/arena01/src/course-config.json
+++ b/arenas/arena01/src/course-config.json
@@ -11,7 +11,6 @@
     "descriptionEn": "Learn to manipulate the filesystem, speak binary, use backtracking to solve complex problems to become a true developer!",
     "coverUrl": "https://firebasestorage.googleapis.com/v0/b/thearenaproject.appspot.com/o/public%2Fcourses%2Fcourse-00.jpeg?alt=media",
     "chapters": [
-        "shell",
         "fundamentals",
         "recursive",
         "binary",

--- a/arenas/arena01/src/course-config.json
+++ b/arenas/arena01/src/course-config.json
@@ -11,6 +11,7 @@
     "descriptionEn": "Learn to manipulate the filesystem, speak binary, use backtracking to solve complex problems to become a true developer!",
     "coverUrl": "https://firebasestorage.googleapis.com/v0/b/thearenaproject.appspot.com/o/public%2Fcourses%2Fcourse-00.jpeg?alt=media",
     "chapters": [
+        "fundamentals",
         "recursive",
         "binary",
         "filesystem",

--- a/arenas/arena01/src/course-config.json
+++ b/arenas/arena01/src/course-config.json
@@ -11,7 +11,6 @@
     "descriptionEn": "Learn to manipulate the filesystem, speak binary, use backtracking to solve complex problems to become a true developer!",
     "coverUrl": "https://firebasestorage.googleapis.com/v0/b/thearenaproject.appspot.com/o/public%2Fcourses%2Fcourse-00.jpeg?alt=media",
     "chapters": [
-        "fundamentals",
         "recursive",
         "binary",
         "filesystem",

--- a/jest.config.js
+++ b/jest.config.js
@@ -2,7 +2,7 @@
 module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testTimeout: 20000,
+  testTimeout: 50000,
   transform: {
     '^.+\\.ts?$': ['ts-jest', { tsconfig: 'jest.tsconfig.json'  }]
   }


### PR DESCRIPTION
We've decided to remove the shell fight from this Arena for consistency reasons.

Many users were complaining about the fact it was confusing to start a TypeScript-based course by a shell module.

We will probably add this shell fight into a dedicated Arena we may develop later.