### PR TITLE
Fix missing translations in mini-sql fight

### DIFF
--- a/arenas/arena01/src/challenges/mini-sql/challenge-en.md
+++ b/arenas/arena01/src/challenges/mini-sql/challenge-en.md
@@ -108,7 +108,7 @@ miniSQL$ INSERT "wise julius"
 added: id=3, username=wise julius
 ```
 
-La commande `SELECT` prend en argument optionnel un `username` et retourne toutes les entrées correspondantes qui sont stockées sur le disque en affichant le nombre de résultats disponibles, comme dans l'exemple suivant :
+The SELECT command takes an optional username argument and returns all matching entries stored on the disk, displaying the number of available results, as in the following examples:
 
 ```bash
 $> npm run start
@@ -117,8 +117,6 @@ found 2 entries:
 -> id=1, username=julius
 -> id=5, username=julius
 ```
-
-The SELECT command takes an optional username argument and returns all matching entries stored on the disk, displaying the number of available results, as in the following example:
 
 ```bash
 $> npm run start
@@ -171,14 +169,14 @@ Here is an example of using build and start:
 
 ```bash
 $> npm run build
-# peu importe l'output de votre commande de build
+# your build command's output does not matter
 $> npm run start
 miniSQL$
 ```
 
 To test your code, we will clone your submission folder, install all the allowed packages, and then inject your package.json to run a build and start your program with your start script.
 
-# Contraintes de performance
+# Constraints
 
 We do not impose any performance constraints.
 

--- a/arenas/arena01/src/challenges/mini-sql/config.json
+++ b/arenas/arena01/src/challenges/mini-sql/config.json
@@ -3,11 +3,11 @@
   "name": "Minisql",
   "baseScore": 3000,
   "scorePenaltyPerAttempt": 250,
-  "turnedInFile": "Tous les fichiers nécessaires",
+  "turnedInFile": "All necessary files",
   "hint": null,
   "slideDecks": [],
   "allowedMaterials": [
-    "Toutes les fonctions natives de Typescript et de la librairie standard de NodeJS"
+    "Every native function from Typescript and NodeJS's standard library"
   ],
   "nameFr": "Minisql",
   "nameEn": "Minisql",


### PR DESCRIPTION
The last fight (mini-sql) still has some french remaining in its challenge instructions and submission rules.

This PR removes some redudant english/french text and translate the remaining french into english.

Brief explanation of changes + screenshots of state before changes:

- Removed the first paragraph, moved the code block below the english text to show both examples with entries and without.

![image](https://user-images.githubusercontent.com/11755096/235802405-9ae75c83-7435-4aa6-91cf-402fe1e3d94e.png)

- Translated the comment 

![image](https://user-images.githubusercontent.com/11755096/235802422-f4b3dfd7-fbad-48c0-a595-6a0bb6c1a2df.png)

- Translated the title

![image](https://user-images.githubusercontent.com/11755096/235802455-5fa2db8e-6c7f-444b-8b4a-4d4e8b8f68c4.png)

- Translated the instructions

![image](https://user-images.githubusercontent.com/11755096/235802486-7a7102af-7733-425f-aad9-5c265948bb50.png)

